### PR TITLE
fix: include helm parameters when not empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See [Basic example](examples/basic/README.md) for further information.
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.19.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.6.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.11.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.20.0 |
 | <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.17.0 |
 
 ## Modules

--- a/argo.tf
+++ b/argo.tf
@@ -10,11 +10,15 @@ locals {
       "repoURL" : var.helm_repo_url
       "chart" : var.helm_chart_name
       "targetRevision" : var.helm_chart_version
-      "helm" : {
-        "releaseName" : var.helm_release_name
-        "parameters" : [for k, v in var.settings : tomap({ "forceString" : true, "name" : k, "value" : v })]
-        "values" : var.enabled ? data.utils_deep_merge_yaml.values[0].output : ""
-      }
+      "helm" : merge(
+        {
+          "releaseName" : var.helm_release_name
+          "values" : var.enabled ? data.utils_deep_merge_yaml.values[0].output : ""
+        },
+        length(var.settings) > 0 ? {
+          "parameters" : [for k, v in var.settings : tomap({ "forceString" : true, "name" : k, "value" : v })]
+        } : {}
+      )
     }
     "destination" : {
       "server" : var.argo_destination_server

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -10,7 +10,7 @@ The code in this example shows how to use the module with basic configuration an
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.6.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.11.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.20.0 |
 
 ## Modules
 

--- a/examples/basic/base.tf
+++ b/examples/basic/base.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.14.2"
 
-  name               = "cluster-autoscaler-vpc"
+  name               = "github-actions-runner-vpc"
   cidr               = "10.0.0.0/16"
   azs                = ["eu-central-1a", "eu-central-1b"]
   public_subnets     = ["10.0.101.0/24", "10.0.102.0/24"]

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.11.0"
+      version = ">= 2.20.0"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.11.0"
+      version = ">= 2.20.0"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->
- Include Helm parameters in ArgoCD Apps source when not empty. This ensures compatibility with Terraform K8s provider > 2.20

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)
